### PR TITLE
refactor/legacy_audio

### DIFF
--- a/ovos_audio_plugin_simple/__init__.py
+++ b/ovos_audio_plugin_simple/__init__.py
@@ -11,6 +11,38 @@ from ovos_plugin_manager.templates.audio import AudioBackend
 from ovos_utils.log import LOG
 from requests import Session
 
+try:
+    from ovos_utils.ocp import MediaState
+except ImportError:
+    LOG.warning("Please update to ovos-utils~=0.1.")
+    from enum import IntEnum
+
+
+    class MediaState(IntEnum):
+        # https://doc.qt.io/qt-5/qmediaplayer.html#MediaStatus-enum
+        # The status of the media cannot be determined.
+        UNKNOWN = 0
+        # There is no current media. PlayerState == STOPPED
+        NO_MEDIA = 1
+        # The current media is being loaded. The player may be in any state.
+        LOADING_MEDIA = 2
+        # The current media has been loaded. PlayerState== STOPPED
+        LOADED_MEDIA = 3
+        # Playback of the current media has stalled due to
+        # insufficient buffering or some other temporary interruption.
+        # PlayerState != STOPPED
+        STALLED_MEDIA = 4
+        # The player is buffering data but has enough data buffered
+        # for playback to continue for the immediate future.
+        # PlayerState != STOPPED
+        BUFFERING_MEDIA = 5
+        # The player has fully buffered the current media. PlayerState != STOPPED
+        BUFFERED_MEDIA = 6
+        # Playback has reached the end of the current media. PlayerState == STOPPED
+        END_OF_MEDIA = 7
+        # The current media cannot be played. PlayerState == STOPPED
+        INVALID_MEDIA = 8
+
 
 def find_mime(path):
     mime = None
@@ -166,7 +198,11 @@ class OVOSSimpleService(AudioBackend):
             else:
                 self.process = None
         else:
-            self.ocp_error()
+            try:
+                self.ocp_error()
+            except:  # too old OPM version
+                self.bus.emit(Message("ovos.common_play.media.state",
+                                      {"state": MediaState.INVALID_MEDIA}))
 
         self._track_start_callback(None)
         self._is_playing = False

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,2 +1,1 @@
 ovos-plugin-manager
-ovos_plugin_common_play


### PR DESCRIPTION
add missing abstract methods

implement fake playback_time tracking

drop dependency on common_play base class

helps keeping the legacy plugins alive independently of OCP

companion PR: https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/226 https://github.com/OpenVoiceOS/ovos-audio/pull/64